### PR TITLE
Feature/10 notification

### DIFF
--- a/app/assets/stylesheets/_header.scss
+++ b/app/assets/stylesheets/_header.scss
@@ -1,0 +1,11 @@
+#header-activities {
+  width: 400px;
+  .dropdown-item {
+    max-width: initial;
+    font-size: 12px;
+  }
+
+  .read {
+    background: #f1f1f1;
+  }
+}

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -119,3 +119,10 @@ img {
     object-fit: cover;
   }
 }
+
+#header-activities {
+  width: 400px;
+  .dropdown-item {
+    font-size: 12px;
+  }
+}

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -4,6 +4,7 @@
 //FontAwesome導入
 @import 'font-awesome-sprockets';
 @import 'font-awesome';
+@import 'header'; 
 
 
 body {
@@ -117,12 +118,5 @@ img {
     top: 0;
     // トリミングする
     object-fit: cover;
-  }
-}
-
-#header-activities {
-  width: 400px;
-  .dropdown-item {
-    font-size: 12px;
   }
 }

--- a/app/assets/stylesheets/mypage.scss
+++ b/app/assets/stylesheets/mypage.scss
@@ -6,3 +6,7 @@
 main {
   padding-top: 50px;
 }
+
+.read {
+  background: #f1f1f1;
+}

--- a/app/assets/stylesheets/mypage.scss
+++ b/app/assets/stylesheets/mypage.scss
@@ -1,4 +1,7 @@
 @import 'bootstrap-material-design/dist/css/bootstrap-material-design';
+@import 'font-awesome-sprockets';
+@import 'font-awesome';
+@import 'header';
 
 main {
   padding-top: 50px;

--- a/app/controllers/activities_controller.rb
+++ b/app/controllers/activities_controller.rb
@@ -1,0 +1,2 @@
+class ActivitiesController < ApplicationController
+end

--- a/app/controllers/activities_controller.rb
+++ b/app/controllers/activities_controller.rb
@@ -1,2 +1,10 @@
 class ActivitiesController < ApplicationController
+  before_action :require_login, only: %i[read]
+
+  def read
+    activity = current_user.activities.find(params[:id])
+    # read!でreadカラムの値をreadに更新。read!とunread?はenumによって追加されたメソッド。
+    activity.read! if activity.unread?
+    redirect_to activity.redirect_path
+  end
 end

--- a/app/controllers/mypage/activities_controller.rb
+++ b/app/controllers/mypage/activities_controller.rb
@@ -1,0 +1,8 @@
+class Mypage::ActivitiesController < Mypage::BaseController
+  before_action :require_login, only: %i[index]
+
+  def index
+    @activities = current_user.activities.order(created_at: :desc).page(params[:page]).per(10)
+  end
+  
+end

--- a/app/controllers/mypage/activities_controller.rb
+++ b/app/controllers/mypage/activities_controller.rb
@@ -4,5 +4,4 @@ class Mypage::ActivitiesController < Mypage::BaseController
   def index
     @activities = current_user.activities.order(created_at: :desc).page(params[:page]).per(10)
   end
-  
 end

--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -1,0 +1,30 @@
+# == Schema Information
+#
+# Table name: activities
+#
+#  id           :bigint           not null, primary key
+#  action_type  :integer          not null
+#  read         :boolean          default(FALSE), not null
+#  subject_type :string(255)
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
+#  subject_id   :bigint
+#  user_id      :bigint
+#
+# Indexes
+#
+#  index_activities_on_subject_type_and_subject_id  (subject_type,subject_id)
+#  index_activities_on_user_id                      (user_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (user_id => users.id)
+#
+class Activity < ApplicationRecord
+  # ポリモーフィック関連づけを行っている。
+  belongs_to :subject, polymorphic: true
+  belongs_to :user
+
+  # enumは、一つのカラムに指定した複数個の定数を保存できるようにする。データベースにはハッシュのバリューが保存され、action_typeカラムにはハッシュのキー名を保存する。
+  enum action_type: { commented_to_own_post: 0, liked_to_own_post: 1, followed_me: 2 }
+end

--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -4,7 +4,7 @@
 #
 #  id           :bigint           not null, primary key
 #  action_type  :integer          not null
-#  read         :boolean          default(FALSE), not null
+#  read         :boolean          default("unread"), not null
 #  subject_type :string(255)
 #  created_at   :datetime         not null
 #  updated_at   :datetime         not null
@@ -21,10 +21,32 @@
 #  fk_rails_...  (user_id => users.id)
 #
 class Activity < ApplicationRecord
+  # モデルでpost_pathなどのパスを使用したい場合は、これを書く必要がある。
+  include Rails.application.routes.url_helpers
+
   # ポリモーフィック関連づけを行っている。
   belongs_to :subject, polymorphic: true
   belongs_to :user
 
+  scope :recent, ->(count) { order(created_at: :desc).limit(count) }
+
   # enumは、一つのカラムに指定した複数個の定数を保存できるようにする。データベースにはハッシュのバリューが保存され、action_typeカラムにはハッシュのキー名を保存する。
   enum action_type: { commented_to_own_post: 0, liked_to_own_post: 1, followed_me: 2 }
+
+  # enumでreadカラムの値をunreadとreadに限定する。
+  enum read: { unread: false, read: true }
+
+  def redirect_path
+    case action_type.to_sym
+    # action_typeごとにクライアントに返すページを分ける
+    when :commented_to_own_post
+      # anchorオプションでanchorリンクが生成される。urlの末尾に#comment-idが追加され、id="comment-id"がついているタグに飛ぶ。
+      post_path(self.subject.post, anchor: "comment-#{subject.id}")
+    when :liked_to_own_post
+      post_path(self.subject.post)
+    when :followed_me
+      user_path(self.subject.follower)
+    end
+  end
+  
 end

--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -24,7 +24,7 @@ class Activity < ApplicationRecord
   # モデルでpost_pathなどのパスを使用したい場合は、これを書く必要がある。
   include Rails.application.routes.url_helpers
 
-  # ポリモーフィック関連づけを行っている。
+  # ポリモーフィック関連づけを行っている。object.subjectで対応するオブジェクトをクラスを気にせずに取得できる。
   belongs_to :subject, polymorphic: true
   belongs_to :user
 

--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -41,12 +41,11 @@ class Activity < ApplicationRecord
     # action_typeごとにクライアントに返すページを分ける
     when :commented_to_own_post
       # anchorオプションでanchorリンクが生成される。urlの末尾に#comment-idが追加され、id="comment-id"がついているタグに飛ぶ。
-      post_path(self.subject.post, anchor: "comment-#{subject.id}")
+      post_path(subject.post, anchor: "comment-#{subject.id}")
     when :liked_to_own_post
-      post_path(self.subject.post)
+      post_path(subject.post)
     when :followed_me
-      user_path(self.subject.follower)
+      user_path(subject.follower)
     end
   end
-  
 end

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -20,8 +20,19 @@
 #  fk_rails_...  (user_id => users.id)
 #
 class Comment < ApplicationRecord
-  validates :body, presence: true, length: { maximum: 1000 }
-
   belongs_to :user
   belongs_to :post
+  # ポリモーフィック関連づけ
+  has_one :activity, as: :subject, dependent: :destroy
+
+  validates :body, presence: true, length: { maximum: 1000 }
+
+  after_create_commit :create_activities
+
+  private
+  # self.post.userで投稿にコメントされたユーザーを取得できる。
+  def create_activities
+    Activity.create(subject: self, user: self.post.user, action_type: :commented_to_own_post)
+  end
+  
 end

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -31,9 +31,9 @@ class Comment < ApplicationRecord
   after_create_commit :create_activities
 
   private
+
   # self.post.userで投稿にコメントされたユーザーを取得できる。
   def create_activities
-    Activity.create(subject: self, user: self.post.user, action_type: :commented_to_own_post)
+    Activity.create(subject: self, user: post.user, action_type: :commented_to_own_post)
   end
-  
 end

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -22,11 +22,12 @@
 class Comment < ApplicationRecord
   belongs_to :user
   belongs_to :post
-  # ポリモーフィック関連づけ
+  # コメントを一度したら、通知は一つしか作成されないので、has_oneを使用する。as: :subjectでポリモーフィック関連づけを行っている。
   has_one :activity, as: :subject, dependent: :destroy
 
   validates :body, presence: true, length: { maximum: 1000 }
 
+  # データベースにレコードが挿入されるとcreate_activitiesメソッドが呼び出される。
   after_create_commit :create_activities
 
   private

--- a/app/models/like.rb
+++ b/app/models/like.rb
@@ -22,6 +22,17 @@
 class Like < ApplicationRecord
   belongs_to :user
   belongs_to :post
+  # ポリモーフィック関連づけをしている。object.activityで対応するactivityに繋がる。as: :subjectはポリモーフィック関連なのでオブジェクトのクラスを意識する必要がない。
+  has_one :activity, as: :subject, dependent: :destroy
   # post_idとuser_idの組が１組しかないようにバリデーションをかける
   validates :user_id, uniqueness: { scope: :post_id }
+  # データベースにレコードが挿入されるとcreate_activitiesメソッドが呼び出される。
+  after_create_commit :create_activities
+
+  private
+  def create_activities
+    # likeモデルのインスタンスメソッドの中なので、selfはlikeモデルのオブジェクトになる。self.post.userでいいねされた方のユーザーを取得できる。
+    Activity.create(subject: self, user: self.post.user, action_type: :liked_to_own_post)
+  end
+  
 end

--- a/app/models/like.rb
+++ b/app/models/like.rb
@@ -22,7 +22,7 @@
 class Like < ApplicationRecord
   belongs_to :user
   belongs_to :post
-  # ポリモーフィック関連づけをしている。object.activityで対応するactivityに繋がる。as: :subjectはポリモーフィック関連なのでオブジェクトのクラスを意識する必要がない。
+  # いいねを一度したら、通知は一つしか作成されないので、has_oneを使用する。as: :subjectでポリモーフィック関連づけを行っている。
   has_one :activity, as: :subject, dependent: :destroy
   # post_idとuser_idの組が１組しかないようにバリデーションをかける
   validates :user_id, uniqueness: { scope: :post_id }

--- a/app/models/like.rb
+++ b/app/models/like.rb
@@ -30,9 +30,9 @@ class Like < ApplicationRecord
   after_create_commit :create_activities
 
   private
+
   def create_activities
     # likeモデルのインスタンスメソッドの中なので、selfはlikeモデルのオブジェクトになる。self.post.userでいいねされた方のユーザーを取得できる。
-    Activity.create(subject: self, user: self.post.user, action_type: :liked_to_own_post)
+    Activity.create(subject: self, user: post.user, action_type: :liked_to_own_post)
   end
-  
 end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -32,4 +32,6 @@ class Post < ApplicationRecord
   has_many :likes, dependent: :destroy
   # 投稿にいいねしているユーザーを取得できるメソッド。likesテーブルを経由して、usersテーブルを参照する。
   has_many :like_users, through: :likes, source: :user
+  # ポリモーフィック関連づけ
+  has_one :activity, as: :subject, dependent: :destroy
 end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -32,6 +32,6 @@ class Post < ApplicationRecord
   has_many :likes, dependent: :destroy
   # 投稿にいいねしているユーザーを取得できるメソッド。likesテーブルを経由して、usersテーブルを参照する。
   has_many :like_users, through: :likes, source: :user
-  # ポリモーフィック関連づけ
+  # 一つの投稿には一つの通知しかされないので、has_oneを使用。as: :subjectでポリモーフィック関連づけを行っている。
   has_one :activity, as: :subject, dependent: :destroy
 end

--- a/app/models/relationship.rb
+++ b/app/models/relationship.rb
@@ -19,7 +19,7 @@ class Relationship < ApplicationRecord
   belongs_to :follower, class_name: 'User'
   # 仮想のfollowedモデルを作っている。実際はuserモデルであるためclass_nameオプションをつける。
   belongs_to :followed, class_name: 'User'
-  # ポリモーフィック関連づけ。
+  # フォロー機能には一つの通知しか作成されないから、has_oneを使用。as: :subjectでポリモフィック関連づけを行っている。
   has_one :activity, as: :subject, dependent: :destroy
   validates :follower_id, presence: true
   validates :followed_id, presence: true
@@ -29,8 +29,8 @@ class Relationship < ApplicationRecord
   after_create_commit :create_activities
 
   private
-  # self.followedでフォローされたユーザーを取得できる。
   def create_activities
+    # self.followedでフォローされたユーザーを取得できる。
     Activity.create(subject: self, user: followed, action_type: :followed_me)
   end
   

--- a/app/models/relationship.rb
+++ b/app/models/relationship.rb
@@ -19,8 +19,19 @@ class Relationship < ApplicationRecord
   belongs_to :follower, class_name: 'User'
   # 仮想のfollowedモデルを作っている。実際はuserモデルであるためclass_nameオプションをつける。
   belongs_to :followed, class_name: 'User'
+  # ポリモーフィック関連づけ。
+  has_one :activity, as: :subject, dependent: :destroy
   validates :follower_id, presence: true
   validates :followed_id, presence: true
   # follower_idとfollowed_idをセットでユニーク制約をかける。同じユーザーへのフォローを複数回できることを禁止する。
   validates :follower_id, uniqueness: { scope: :followed_id }
+
+  after_create_commit :create_activities
+
+  private
+  # self.followedでフォローされたユーザーを取得できる。
+  def create_activities
+    Activity.create(subject: self, user: followed, action_type: :followed_me)
+  end
+  
 end

--- a/app/models/relationship.rb
+++ b/app/models/relationship.rb
@@ -29,9 +29,9 @@ class Relationship < ApplicationRecord
   after_create_commit :create_activities
 
   private
+
   def create_activities
     # self.followedでフォローされたユーザーを取得できる。
     Activity.create(subject: self, user: followed, action_type: :followed_me)
   end
-  
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -48,6 +48,8 @@ class User < ApplicationRecord
   has_many :following, through: :active_relationships, source: :followed
   # ユーザーのフォロワーの値を取得する。
   has_many :followers, through: :passive_relationships, source: :follower
+  # 一人のユーザーは複数の通知がくる
+  has_many :activities, dependent: :destroy
 
   def own?(object)
     id == object.user_id

--- a/app/views/mypage/activities/_commented_to_own_post.html.slim
+++ b/app/views/mypage/activities/_commented_to_own_post.html.slim
@@ -1,0 +1,14 @@
+= link_to read_activity_path(activity), class: "dropdown-item border-bottom #{'read' if activity.read?}", method: :patch do
+  = image_tag activity.subject.user.avatar.url, class: 'rounded-circle mr-1', size: '30x30'
+  object
+    = link_to activity.subject.user.name, user_path(activity.subject.user)
+    | があなたの
+  object
+    = link_to '投稿', post_path(activity.subject.post)
+    | に
+  object
+    / anchorオプションでanchorリンクが生成される。urlの末尾に#comment-idが追加され、id="comment-id"がついているタグに飛ぶ。
+    = link_to 'コメント', post_path(activity.subject.post, anchor: "comment-#{activity.subject.id}}")
+    | しました
+    .text-right
+      = l activity.created_at, format: :short

--- a/app/views/mypage/activities/_followed_me.html.slim
+++ b/app/views/mypage/activities/_followed_me.html.slim
@@ -1,0 +1,7 @@
+= link_to read_activity_path(activity), class: "dropdown-item border-bottom #{'read' if activity.read?}", method: :patch do
+  = image_tag activity.subject.follower.avatar.url, class: 'rounded-circle mr-1', size: '30x30'
+  object
+    = link_to activity.subject.follower.name, user_path(activity.subject.follower)
+  | があなたをフォローしました
+  .text-right
+    = l activity.created_at, format: :short

--- a/app/views/mypage/activities/_liked_to_own_post.html.slim
+++ b/app/views/mypage/activities/_liked_to_own_post.html.slim
@@ -1,0 +1,10 @@
+= link_to read_activity_path(activity), class: "dropdown-item border-bottom #{'read' if activity.read?}", method: :patch do
+  = image_tag activity.subject.user.avatar.url, class: 'rounded-circle mr-1', size: '30x30'
+  object
+    = link_to activity.subject.user.name, user_path(activity.subject.user)
+  | があなたの
+  object
+    = link_to '投稿', post_path(activity.subject.post)
+  | にいいねしました
+  .text-right
+    = l activity.created_at, format: :short

--- a/app/views/mypage/activities/index.html.slim
+++ b/app/views/mypage/activities/index.html.slim
@@ -1,0 +1,3 @@
+- if @activities.present?
+  - @activities.each do |activity|
+    = render "#{activity.action_type}", activity: activity

--- a/app/views/mypage/shared/_sidebar.html.slim
+++ b/app/views/mypage/shared/_sidebar.html.slim
@@ -3,3 +3,6 @@ nab
     li
       = link_to 'プロフィール編集', edit_mypage_account_path
       hr
+    li
+      = link_to '通知一覧', mypage_activities_path
+      hr

--- a/app/views/shared/_commented_to_own_post.html.slim
+++ b/app/views/shared/_commented_to_own_post.html.slim
@@ -1,0 +1,11 @@
+.dropdown-item
+  = image_tag  activity.subject.user.avatar.url, class: 'rounded-circle mr-1', size: '30x30'
+  = link_to activity.subject.user.name, user_path(activity.subject.user)
+  | があなたの
+  = link_to  '投稿', post_path(activity.subject.post)
+  | に
+  = link_to 'コメント', post_path(activity.subject.post, anchor: "comment-#{activity.subject.id}")
+  | しました
+  .ml-auto
+    = l activity.created_at, format: :short
+  .dropdown-driver

--- a/app/views/shared/_commented_to_own_post.html.slim
+++ b/app/views/shared/_commented_to_own_post.html.slim
@@ -1,3 +1,4 @@
+/ activity.read?でactivityオブジェクトのread属性がreadかどうか確認できる。enumによって追加されたメソッド。
 = link_to read_activity_path(activity), class: "dropdown-item border-bottom #{'read' if activity.read?}", method: :patch do 
   = image_tag  activity.subject.user.avatar.url, class: 'rounded-circle mr-1', size: '30x30'
   object

--- a/app/views/shared/_commented_to_own_post.html.slim
+++ b/app/views/shared/_commented_to_own_post.html.slim
@@ -1,11 +1,14 @@
-.dropdown-item
+= link_to read_activity_path(activity), class: "dropdown-item border-bottom #{'read' if activity.read?}", method: :patch do 
   = image_tag  activity.subject.user.avatar.url, class: 'rounded-circle mr-1', size: '30x30'
-  = link_to activity.subject.user.name, user_path(activity.subject.user)
+  object
+    = link_to activity.subject.user.name, user_path(activity.subject.user)
   | があなたの
-  = link_to  '投稿', post_path(activity.subject.post)
+  object
+    = link_to  '投稿', post_path(activity.subject.post)
   | に
-  = link_to 'コメント', post_path(activity.subject.post, anchor: "comment-#{activity.subject.id}")
+  object
+    = link_to 'コメント', post_path(activity.subject.post, anchor: "comment-#{activity.subject.id}")
   | しました
   .ml-auto
+    / lメソッドで日時を読みやすい形に変更する。formatを指定することで、ロケールファイルに書かれている形式で表示させる。
     = l activity.created_at, format: :short
-  .dropdown-driver

--- a/app/views/shared/_followed_me.html.slim
+++ b/app/views/shared/_followed_me.html.slim
@@ -1,0 +1,7 @@
+.dropdown
+  = image_tag activity.subject.follower.avatar.url, class: 'rounded-circle mr-1', size: '30x30'
+  = link_to activity.subject.follower.name, user_path(activity.subject.follower)
+  | があなたをフォローしました
+  .ml-auto
+    = l activity.created_at, format: :short
+.dropdown-driver

--- a/app/views/shared/_followed_me.html.slim
+++ b/app/views/shared/_followed_me.html.slim
@@ -1,7 +1,8 @@
-.dropdown
+= link_to read_activity_path(activity), class: "dropdown-item border-bottom #{'read' if activity.read?}", method: :patch do 
   = image_tag activity.subject.follower.avatar.url, class: 'rounded-circle mr-1', size: '30x30'
-  = link_to activity.subject.follower.name, user_path(activity.subject.follower)
+  object
+    = link_to activity.subject.follower.name, user_path(activity.subject.follower)
   | があなたをフォローしました
   .ml-auto
+    / lメソッドで日時を読みやすい形に変更する。formatを指定することで、ロケールファイルに書かれている形式で表示させる。
     = l activity.created_at, format: :short
-.dropdown-driver

--- a/app/views/shared/_followed_me.html.slim
+++ b/app/views/shared/_followed_me.html.slim
@@ -1,3 +1,4 @@
+/ activity.read?でactivityオブジェクトのread属性がreadかどうか確認できる。enumによって追加されたメソッド。
 = link_to read_activity_path(activity), class: "dropdown-item border-bottom #{'read' if activity.read?}", method: :patch do 
   = image_tag activity.subject.follower.avatar.url, class: 'rounded-circle mr-1', size: '30x30'
   object

--- a/app/views/shared/_header.html.slim
+++ b/app/views/shared/_header.html.slim
@@ -10,9 +10,10 @@ nav.navbar.navbar-expand-lg.navbar-light.bg-white
           = icon 'far', 'image', class: 'fa-lg'
       li.nav-item
         .dropdown
-          a#dropdownMenuButton.nav-link href="#" data-toggle="dropdown" aria-expanded="false" aria-haspopup="true"
+          a#dropdownMenuButton.nav-link.position-relative href="#" data-toggle="dropdown" aria-expanded="false" aria-haspopup="true"
             = icon 'far', 'heart', class: 'fa-lg'
-          #header-activities.dropdown-menu-right aria-labelledby="dropdownMenuButton"
+            = render 'shared/unread_badge'
+          #header-activities.dropdown-menu.dropdown-menu-right.m-0.p-0 aria-labelledby="dropdownMenuButton"
             = render 'shared/header_activities'
       li.nav-item
         = link_to user_path(current_user), class: 'nav-link' do 

--- a/app/views/shared/_header.html.slim
+++ b/app/views/shared/_header.html.slim
@@ -9,8 +9,11 @@ nav.navbar.navbar-expand-lg.navbar-light.bg-white
         = link_to new_post_path, class: 'nav-link' do 
           = icon 'far', 'image', class: 'fa-lg'
       li.nav-item
-        a.nav-link href="#"
-          = icon 'far', 'heart', class: 'fa-lg'
+        .dropdown
+          a#dropdownMenuButton.nav-link href="#" data-toggle="dropdown" aria-expanded="false" aria-haspopup="true"
+            = icon 'far', 'heart', class: 'fa-lg'
+          #header-activities.dropdown-menu-right aria-labelledby="dropdownMenuButton"
+            = render 'shared/header_activities'
       li.nav-item
         = link_to user_path(current_user), class: 'nav-link' do 
           = icon 'far', 'user', class: 'fa-lg'

--- a/app/views/shared/_header_activities.html.slim
+++ b/app/views/shared/_header_activities.html.slim
@@ -1,0 +1,6 @@
+- if current_user.activities.present?
+  - current_user.activities.each do |activity|
+    = render "shared/#{activity.action_type}", activity: activity
+- else
+  .dropdown-item
+    | お知らせはありません

--- a/app/views/shared/_header_activities.html.slim
+++ b/app/views/shared/_header_activities.html.slim
@@ -1,6 +1,8 @@
 - if current_user.activities.present?
-  - current_user.activities.each do |activity|
+  - current_user.activities.recent(10).each do |activity|
     = render "shared/#{activity.action_type}", activity: activity
+  - if current_user.activities.count > 10
+    = link_to 'すべて見る', mypage_activities_path, class: 'dropdown-item justify-content-center'
 - else
   .dropdown-item
     | お知らせはありません

--- a/app/views/shared/_header_activities.html.slim
+++ b/app/views/shared/_header_activities.html.slim
@@ -1,5 +1,6 @@
 - if current_user.activities.present?
   - current_user.activities.recent(10).each do |activity|
+    / activity.action_type属性の値によって返すテンプレートを場合分けする。こうすることで、activity.subjectで取得してきたオブジェクトに対して使えるメソッドが決まる。
     = render "shared/#{activity.action_type}", activity: activity
   - if current_user.activities.count > 10
     = link_to 'すべて見る', mypage_activities_path, class: 'dropdown-item justify-content-center'

--- a/app/views/shared/_liked_to_own_post.html.slim
+++ b/app/views/shared/_liked_to_own_post.html.slim
@@ -1,3 +1,4 @@
+/ activity.read?でactivityオブジェクトのread属性がreadかどうか確認できる。enumによって追加されたメソッド。
 = link_to read_activity_path(activity), class: "dropdown-item border-bottom #{'read' if activity.read?}", method: :patch do 
   / activity.subjectで関連するオブジェクトを取得する。
   = image_tag activity.subject.user.avatar.url, class: 'rounded-circle mr-1', size: '30x30'

--- a/app/views/shared/_liked_to_own_post.html.slim
+++ b/app/views/shared/_liked_to_own_post.html.slim
@@ -1,11 +1,12 @@
-.dropdown-item
+= link_to read_activity_path(activity), class: "dropdown-item border-bottom #{'read' if activity.read?}", method: :patch do 
   / activity.subjectで関連するオブジェクトを取得する。
   = image_tag activity.subject.user.avatar.url, class: 'rounded-circle mr-1', size: '30x30'
-  = link_to activity.subject.user.name, user_path(activity.subject.user)
+  object
+    = link_to activity.subject.user.name, user_path(activity.subject.user)
   | があなたの
-  = link_to  '投稿', post_path(activity.subject.post) 
+  object
+    = link_to  '投稿', post_path(activity.subject.post) 
   | にいいねしました
   .ml-auto
-    / 意味わからん
+    / lメソッドで日時を読みやすい形に変更する。formatを指定することで、ロケールファイルに書かれている形式で表示させる。
     = l activity.created_at, format: :short
-.dropdown-driver

--- a/app/views/shared/_liked_to_own_post.html.slim
+++ b/app/views/shared/_liked_to_own_post.html.slim
@@ -1,0 +1,11 @@
+.dropdown-item
+  / activity.subjectで関連するオブジェクトを取得する。
+  = image_tag activity.subject.user.avatar.url, class: 'rounded-circle mr-1', size: '30x30'
+  = link_to activity.subject.user.name, user_path(activity.subject.user)
+  | があなたの
+  = link_to  '投稿', post_path(activity.subject.post) 
+  | にいいねしました
+  .ml-auto
+    / 意味わからん
+    = l activity.created_at, format: :short
+.dropdown-driver

--- a/app/views/shared/_unread_badge.html.slim
+++ b/app/views/shared/_unread_badge.html.slim
@@ -1,0 +1,3 @@
+- if current_user.activities.unread.count > 0
+  span.badge.badge-warning.navbar-bagde.position-absolute style='top: 0; right: 0;'
+    = current_user.activities.unread.count

--- a/config/locales/modei.ja.yml
+++ b/config/locales/modei.ja.yml
@@ -18,3 +18,9 @@ ja:
   attributes:
     created_at: 登録日
     updated_at: 更新日
+  # 日時を読みやすい形に指定する。formatごとに表示の仕方を変えるようにした
+  time:
+    formats: 
+      default: "%Y年%m月%d日(%a) %H時%M分%S秒 %z"
+      long: "%Y/%m/%d %H:%M"
+      short: "%m/%d %H:%M"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -26,10 +26,12 @@
 #       edit_mypage_account GET    /mypage/account/edit(.:format)                                                           mypage/accounts#edit
 #            mypage_account PATCH  /mypage/account(.:format)                                                                mypage/accounts#update
 #                           PUT    /mypage/account(.:format)                                                                mypage/accounts#update
+#         mypage_activities GET    /mypage/activities(.:format)                                                             mypage/activities#index
 #                     likes POST   /likes(.:format)                                                                         likes#create
 #                      like DELETE /likes/:id(.:format)                                                                     likes#destroy
 #             relationships POST   /relationships(.:format)                                                                 relationships#create
 #              relationship DELETE /relationships/:id(.:format)                                                             relationships#destroy
+#             read_activity PATCH  /activities/:id/read(.:format)                                                           activities#read
 #        rails_service_blob GET    /rails/active_storage/blobs/:signed_id/*filename(.:format)                               active_storage/blobs#show
 # rails_blob_representation GET    /rails/active_storage/representations/:signed_blob_id/:variation_key/*filename(.:format) active_storage/representations#show
 #        rails_disk_service GET    /rails/active_storage/disk/:encoded_key/*filename(.:format)                              active_storage/disk#show
@@ -56,8 +58,15 @@ Rails.application.routes.draw do
   namespace :mypage do
     # ログインユーザーにとってアカウント編集ページは一つしかないので、単一のresourceを使う。index用のルーティングは存在しない。
     resource :account, only: %i[edit update]
+    resources :activities, only: %i[index]
   end
 
   resources :likes, only: %i[create destroy]
   resources :relationships, only: %i[create destroy]
+
+  # urlをactivities/:id/readのみに限定するため、onlyで絞る。
+  resources :activities, only: [] do
+    # memberオプションでactivities/:idというurlが生成される。この場合は、activitiesコントローラーのreadアクションにリクエストを送る。一つしかない場合は、このような書き方ができる。
+    patch :read, on: :member
+  end
 end

--- a/db/migrate/20200801055308_create_activities.rb
+++ b/db/migrate/20200801055308_create_activities.rb
@@ -1,0 +1,14 @@
+class CreateActivities < ActiveRecord::Migration[5.2]
+  def change
+    create_table :activities do |t|
+      # ポリモーフィック関連。
+      t.references :subject, polymorphic: true
+      t.references :user, foreign_key: true
+      # enumで定数を制限するため、integer方にしている。
+      t.integer :action_type, null: false
+      t.boolean :read, null: false, default: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20200801055308_create_activities.rb
+++ b/db/migrate/20200801055308_create_activities.rb
@@ -1,11 +1,12 @@
 class CreateActivities < ActiveRecord::Migration[5.2]
   def change
     create_table :activities do |t|
-      # ポリモーフィック関連。
+      # ポリモーフィック関連。object.subjectでオブジェクトのクラスを気にせずに対応する値がとれる。
       t.references :subject, polymorphic: true
       t.references :user, foreign_key: true
-      # enumで定数を制限するため、integer方にしている。
+      # enumでactio_typeの値を制限するため、integer型にしている。
       t.integer :action_type, null: false
+      # enumでreadの値を制限するため、boolean型にしている。boolean型の場合は、defaultの値を入れておく。
       t.boolean :read, null: false, default: false
 
       t.timestamps

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,20 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_07_30_054747) do
+ActiveRecord::Schema.define(version: 2020_08_01_055308) do
+
+  create_table "activities", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    # subject_typeで、オブジェクトのクラスを判断している。
+    t.string "subject_type"
+    t.bigint "subject_id"
+    t.bigint "user_id"
+    t.integer "action_type", null: false
+    t.boolean "read", default: false, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["subject_type", "subject_id"], name: "index_activities_on_subject_type_and_subject_id"
+    t.index ["user_id"], name: "index_activities_on_user_id"
+  end
 
   create_table "comments", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "body", null: false
@@ -62,6 +75,7 @@ ActiveRecord::Schema.define(version: 2020_07_30_054747) do
     t.index ["email"], name: "index_users_on_email", unique: true
   end
 
+  add_foreign_key "activities", "users"
   add_foreign_key "comments", "posts"
   add_foreign_key "comments", "users"
   add_foreign_key "likes", "posts"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -15,6 +15,7 @@ ActiveRecord::Schema.define(version: 2020_08_01_055308) do
   create_table "activities", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     # subject_typeで、オブジェクトのクラスを判断している。
     t.string "subject_type"
+    # subeject_idで、オブジェクトのidを取得する。
     t.bigint "subject_id"
     t.bigint "user_id"
     t.integer "action_type", null: false


### PR DESCRIPTION
# 概要

・通知機能を実装
・タイミングと文言は以下の通り。
・フォローされたとき
    xxx（リンク）があなたをフォローしました
    通知そのものに対してはxxxへのリンクを張る
・自分の投稿にいいねがあったとき
    xxx（リンク）があなたの投稿（リンク）にいいねしました
    通知そのものに対しては投稿へのリンクを張る
・自分の投稿にコメントがあったとき
    xxx（リンク）があなたの投稿（リンク）にコメント（リンク）しました
    通知そのものに対してはコメントへのリンクを張る（厳密には投稿ページに遷移し当該コメント部分にページ内ジャンプするイメージ）
・既読判定も実装。通知一覧において、既読のものは薄暗い背景で、未読のものは白い背景で表示。
・既読とするタイミングは各通知そのものをクリックした時とする。
・不自然ではあるが通知の元となったリソースが削除された際には通知自体も削除する仕様とした。

# 確認方法

・新しくモデルを追加したので```rails db:migrate```でマイグレーション
・```redis-server```でredisの立ち上げ
・```rails s```でサーバーの立ち上げ

# コメント

最初ポリモーフィック関連と通知機能について同時に考えていたので、よく理解できなかったがなぜ通知機能にポリモーフィック関連を使用するのかを理解したら、一気に理解できるようになった。

ちなみにポリモーフィック関連を使う理由は、通知機能は本来comment_idやpost_idなどの様々なモデルと関連している。これに新しい機能の通知機能を追加しようとすると通知モデルにカラムを追加しないといけない。このことが、機能を追加されるごとに行われると大変で拡張性がよくない。そのため、ポリモーフィック関連を使用して一意の方法で関連する値を取れるようにするためである。

もし間違ってたらご指摘お願いします！


