### PR TITLE
Feature/12 install sidekiq

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -64,6 +64,7 @@ gem 'kaminari'
 gem 'config'
 
 gem 'sidekiq'
+gem 'sinatra', require: false
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console

--- a/Gemfile
+++ b/Gemfile
@@ -63,6 +63,8 @@ gem 'kaminari'
 # 環境毎に定数管理
 gem 'config'
 
+gem 'sidekiq'
+
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platforms: %i[mri mingw x64_mingw]

--- a/Gemfile
+++ b/Gemfile
@@ -62,8 +62,9 @@ gem 'faker'
 gem 'kaminari'
 # 環境毎に定数管理
 gem 'config'
-
+# ジョブの永続化のために必要なアダプタ
 gem 'sidekiq'
+# ダッシュボードを表示するために必要
 gem 'sinatra', require: false
 
 group :development, :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -193,6 +193,8 @@ GEM
     multi_json (1.14.1)
     multi_xml (0.6.0)
     multipart-post (2.1.1)
+    mustermann (1.1.1)
+      ruby2_keywords (~> 0.0.1)
     mysql2 (0.5.3)
     nio4r (2.5.2)
     nokogiri (1.10.9)
@@ -218,6 +220,8 @@ GEM
     public_suffix (4.0.5)
     puma (3.12.6)
     rack (2.2.3)
+    rack-protection (2.0.8.1)
+      rack
     rack-test (1.1.0)
       rack (>= 1.0, < 3)
     rails (5.2.4.3)
@@ -289,6 +293,7 @@ GEM
     ruby-progressbar (1.10.1)
     ruby-vips (2.0.15)
       ffi (~> 1.9)
+    ruby2_keywords (0.0.2)
     ruby_dep (1.5.0)
     rubyzip (2.3.0)
     sass (3.7.4)
@@ -311,6 +316,11 @@ GEM
       connection_pool (>= 2.2.2)
       rack (~> 2.0)
       redis (>= 4.2.0)
+    sinatra (2.0.8.1)
+      mustermann (~> 1.0)
+      rack (~> 2.0)
+      rack-protection (= 2.0.8.1)
+      tilt (~> 2.0)
     slim (4.1.0)
       temple (>= 0.7.6, < 0.9)
       tilt (>= 2.0.6, < 2.1)
@@ -386,6 +396,7 @@ DEPENDENCIES
   sass-rails (~> 5.0)
   selenium-webdriver
   sidekiq
+  sinatra
   slim-rails
   sorcery
   spring

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -87,6 +87,7 @@ GEM
     config (2.2.1)
       deep_merge (~> 1.2, >= 1.2.1)
       dry-validation (~> 1.0, >= 1.0.0)
+    connection_pool (2.2.3)
     crass (1.0.6)
     debug_inspector (0.0.3)
     deep_merge (1.2.1)
@@ -306,6 +307,10 @@ GEM
     selenium-webdriver (3.142.7)
       childprocess (>= 0.5, < 4.0)
       rubyzip (>= 1.2.2)
+    sidekiq (6.1.1)
+      connection_pool (>= 2.2.2)
+      rack (~> 2.0)
+      redis (>= 4.2.0)
     slim (4.1.0)
       temple (>= 0.7.6, < 0.9)
       tilt (>= 2.0.6, < 2.1)
@@ -380,6 +385,7 @@ DEPENDENCIES
   rubocop-rails
   sass-rails (~> 5.0)
   selenium-webdriver
+  sidekiq
   slim-rails
   sorcery
   spring

--- a/config/application.rb
+++ b/config/application.rb
@@ -29,6 +29,7 @@ module InstaClone
     # config/locale以下のファイルが読み込めるようにパスを通す
     config.i18n.load_path += Dir[Rails.root.join('config', 'locales', '**', '*.{rb,yml}').to_s]
 
+    # ActiveJobのアダプタをsidekiqに設定
     config.active_job.queue_adapter = :sidekiq
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration can go into files in config/initializers

--- a/config/application.rb
+++ b/config/application.rb
@@ -29,6 +29,7 @@ module InstaClone
     # config/locale以下のファイルが読み込めるようにパスを通す
     config.i18n.load_path += Dir[Rails.root.join('config', 'locales', '**', '*.{rb,yml}').to_s]
 
+    config.active_job.queue_adapter = :sidekiq
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration can go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded after loading

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -1,7 +1,8 @@
+# sidekiq起動時のサーバーとクライアントを設定
 Sidekiq.configure_server do |config|
-  config.redis = { url: 'redis://localhost:6379', namespace: 'test_sidekiq' }
+  config.redis = { url: 'redis://localhost:6379'}
 end
 
 Sidekiq.configure_client do |config|
-  config.redis = { url: 'redis://localhost:6379', namespace: 'test_sidekiq' }
+  config.redis = { url: 'redis://localhost:6379'}
 end

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -1,0 +1,7 @@
+Sidekiq.configure_server do |config|
+  config.redis = { url: 'redis://localhost:6379', namespace: 'test_sidekiq' }
+end
+
+Sidekiq.configure_client do |config|
+  config.redis = { url: 'redis://localhost:6379', namespace: 'test_sidekiq' }
+end

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -1,8 +1,8 @@
 # sidekiq起動時のサーバーとクライアントを設定
 Sidekiq.configure_server do |config|
-  config.redis = { url: 'redis://localhost:6379'}
+  config.redis = { url: 'redis://localhost:6379' }
 end
 
 Sidekiq.configure_client do |config|
-  config.redis = { url: 'redis://localhost:6379'}
+  config.redis = { url: 'redis://localhost:6379' }
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -40,10 +40,13 @@
 
 # annotateで作成された
 Rails.application.routes.draw do
-  # letter_openerを使用した画面の表示のために必要。localhost:3000/letter_openerでメールを確認することができる
-  mount LetterOpenerWeb::Engine, at: '/letter_opener' if Rails.env.development?
   require 'sidekiq/web'
-  mount Sidekiq::Web, at: "/sidekiq"
+  # letter_openerを使用した画面の表示のために必要。localhost:3000/letter_openerでメールを確認することができる
+  if Rails.env.development?
+    mount LetterOpenerWeb::Engine, at: '/letter_opener'
+    # localhost:3000/sidekiqでダッシュボードに繋がる
+    mount Sidekiq::Web, at: "/sidekiq"
+  end
 
   root to: 'posts#index'
   get '/login', to: 'sessions#new'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -45,7 +45,7 @@ Rails.application.routes.draw do
   if Rails.env.development?
     mount LetterOpenerWeb::Engine, at: '/letter_opener'
     # localhost:3000/sidekiqでダッシュボードに繋がる
-    mount Sidekiq::Web, at: "/sidekiq"
+    mount Sidekiq::Web, at: '/sidekiq'
   end
 
   root to: 'posts#index'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -42,6 +42,8 @@
 Rails.application.routes.draw do
   # letter_openerを使用した画面の表示のために必要。localhost:3000/letter_openerでメールを確認することができる
   mount LetterOpenerWeb::Engine, at: '/letter_opener' if Rails.env.development?
+  require 'sidekiq/web'
+  mount Sidekiq::Web, at: "/sidekiq"
 
   root to: 'posts#index'
   get '/login', to: 'sessions#new'

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -1,0 +1,7 @@
+concurrency: 25
+pidfile: ./tmp/pids/sidekiq.pid
+logfile: ./log/sidekiq.log
+queues: 
+  - default
+  - mailers
+deamon: true

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -1,7 +1,5 @@
+# 1つのsidekiqプロセスで使用するスレッド数
 concurrency: 25
-pidfile: ./tmp/pids/sidekiq.pid
-logfile: ./log/sidekiq.log
 queues: 
   - default
   - mailers
-deamon: true


### PR DESCRIPTION
# 概要

・メールのジョブを永続化できるように実装
・ActiveJobのアダプターにはsidekiqを利用

# 確認方法

・新しくgemを追加したので```bundle install --path vendor/bundle```をしてください
・```redis-server```でredisを立ち上げてください
・```bundle exec sidekiq -C config/sidekiq.yml```でsidekiqを立ち上げてください
・```rails s```でサーバーを立ち上げてください

# コメント

ActiveJobの仕組みがなんとなくわかった。定期的なジョブの実行などは使うことは多そうなのでしっかり覚えておきたい。プロセスとかスレッドとかのコンピューターサイエンスの基礎の知識も出てきたので、それも覚える必要があるなと感じた。